### PR TITLE
Add flags to enable serving HTTPS traffic

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ var (
 	prometheusBindPort = kingpin.Flag("prometheus-bind-port", "The port to bind to for prometheus metrics.").Default("8080").OverrideDefaultFromEnvar("PORT").Int()
 	authUsername       = kingpin.Flag("auth-username", "HTTP basic auth username; leave blank to disable basic auth").Default("").OverrideDefaultFromEnvar("AUTH_USERNAME").String()
 	authPassword       = kingpin.Flag("auth-password", "HTTP basic auth password").Default("").OverrideDefaultFromEnvar("AUTH_PASSWORD").String()
+	certFile           = kingpin.Flag("cert-file", "Certificate file for HTTPS").Default("").OverrideDefaultFromEnvar("CF_INSTANCE_CERT").String()
+	keyFile            = kingpin.Flag("key-file", "Key file for HTTPS").Default("").OverrideDefaultFromEnvar("CF_INSTANCE_KEY").String()
 )
 
 type ServiceDiscovery interface {
@@ -136,7 +138,7 @@ func main() {
 	server := buildHTTPServer(*prometheusBindPort, promhttp.Handler(), *authUsername, *authPassword)
 
 	go func() {
-		err := server.ListenAndServe()
+		err := server.ListenAndServeTLS(*certFile, *keyFile)
 		if err != nil {
 			errChan <- err
 		}


### PR DESCRIPTION
Add certFile and keyFile flags to Kingpin that default to the Instance
Identity Credentials in the CF_INSTANCE_CERT and CF_INSTANCE_KEY env
vars to enable serving HTTPS traffic by default. See
https://docs.cloudfoundry.org/devguide/deploy-apps/instance-identity.html
