### PR TITLE
Adjust log processor to scrape correct log

### DIFF
--- a/app/watcher.go
+++ b/app/watcher.go
@@ -245,8 +245,8 @@ func (w *Watcher) processLogMessage(logMessage *sonde_events.LogMessage) error {
 		return nil
 	}
 
-    // Universal app crash log begins with "Process has crashed with type:"
-	if bytes.HasPrefix(logMessage.Message, []byte("Process has crashed with type:")) {
+    // Universal app crash log begins with "Process has crashed"
+	if bytes.HasPrefix(logMessage.Message, []byte("Process has crashed")) {
         // No meta information is available via this log
         // All crashes are associated with first instance available
         w.MetricsForInstance[0].Crash.Inc()

--- a/app/watcher.go
+++ b/app/watcher.go
@@ -3,7 +3,6 @@ package app
 import (
 	"bytes"
 	"context"
-	//"encoding/json"
 	"fmt"
 	"log"
 	"time"

--- a/app/watcher.go
+++ b/app/watcher.go
@@ -3,7 +3,7 @@ package app
 import (
 	"bytes"
 	"context"
-	"encoding/json"
+	//"encoding/json"
 	"fmt"
 	"log"
 	"time"
@@ -245,37 +245,13 @@ func (w *Watcher) processLogMessage(logMessage *sonde_events.LogMessage) error {
 	if logMessage.GetSourceType() != "API" || logMessage.GetMessageType() != sonde_events.LogMessage_OUT {
 		return nil
 	}
-	if !bytes.HasPrefix(logMessage.Message, []byte("App instance exited with guid ")) {
-		return nil
-	}
 
-	payloadStartMarker := []byte(" payload: {")
-	payloadStartMarkerPosition := bytes.Index(logMessage.Message, payloadStartMarker)
-	if payloadStartMarkerPosition < 0 {
-		return fmt.Errorf("unable to find start of payload in app instance exit log: %s", logMessage.Message)
-	}
-	payloadStartPosition := payloadStartMarkerPosition + len(payloadStartMarker) - 1
-
-	payload := logMessage.Message[payloadStartPosition:]
-	payloadAsJson := bytes.Replace(payload, []byte("=>"), []byte(":"), -1)
-
-	var logMessagePayload struct {
-		Index  int    `json:"index"`
-		Reason string `json:"reason"`
-	}
-	err := json.Unmarshal(payloadAsJson, &logMessagePayload)
-	if err != nil {
-		return fmt.Errorf("unable to parse payload in app instance exit log: %s", err)
-	}
-
-	if logMessagePayload.Reason != "CRASHED" {
-		return nil
-	}
-
-	index := logMessagePayload.Index
-	if index < len(w.MetricsForInstance) {
-		w.MetricsForInstance[index].Crash.Inc()
-	}
+    // Universal app crash log begins with "Process has crashed with type:"
+	if bytes.HasPrefix(logMessage.Message, []byte("Process has crashed with type:")) {
+        // No meta information is available via this log
+        // All crashes are associated with first instance available
+        w.MetricsForInstance[0].Crash.Inc()
+    }
 	return nil
 }
 


### PR DESCRIPTION
The original cf-metrics was scraping for a crash log that is not available for rolling deployments, which makes up the majority of IDVA deployments. The log that is being used now does not contain meta information like the previous log so it is not possible to associate crashes with individual instances.
Example original log that was scraped:
```
OUT App instance exited with guid 64830a44-f116-1234-1234-9b3ca79dcc95 payload: {"instance"=>"e08ef3e1-3214-3214-4772-af66", "index"=>0, "cell_id"=>"cadc0ec5-8765-4e5f-4567-fa6a9a8e4fd7", "reason"=>"CRASHED", "exit_description"=>"APP/PROC/WEB: Exited with status 134", "crash_count"=>2, "crash_timestamp"=>1638477297383879944, "version"=>"b1cbca53-4532-44a8-6778-018fb3a9f58f"}
```
Example new log that is scraped:
```
OUT Process has crashed with type: "web"
```
This log has been generating on all crashes but most likely wasn't used for the lack of meta information. For the purpose of seeing crash metrics, it is more valuable since the previously used log is only available for default deployments.